### PR TITLE
Add support for multi language firmware

### DIFF
--- a/update/firmware.php
+++ b/update/firmware.php
@@ -38,7 +38,7 @@ function logHeaders(){
     file_put_contents("headers.txt", gmdate("Y-m-d H:i:s")." - ".$_SERVER['HTTP_X_ESP8266_STA_MAC']." - ".$_SERVER['HTTP_X_ESP8266_AP_MAC']." - ".$_SERVER['HTTP_X_ESP8266_FREE_SPACE']." - ".$_SERVER['HTTP_X_ESP8266_SKETCH_SIZE']." - ".$_SERVER['HTTP_X_ESP8266_CHIP_SIZE']." - ".$_SERVER['HTTP_X_ESP8266_SDK_VERSION']." - ".$_SERVER['HTTP_X_ESP8266_VERSION']."\n", FILE_APPEND | LOCK_EX);
 }
 
-function mac_filter($mac){
+function mac_filter_latest_version($mac){
     $macs[] = "18:FE:34:CF:8C:70";
     $macs[] = "18:FE:34:CF:7C:4B"; // Pragsattel outdoor
     $macs[] = "60:01:94:06:9B:DB"; // Jule
@@ -47,7 +47,7 @@ function mac_filter($mac){
     return in_array($mac, $macs);
 }
 
-function mac_filter_beta($mac){
+function mac_filter_beta_version($mac){
     $macs[] = "18:FE:34:CF:7C:4B"; // Pragsattel outdoor
     $macs[] = "60:01:94:06:9B:DB"; // Jule
     $macs[] = "60:01:94:0B:54:A1"; // Greiz
@@ -86,9 +86,9 @@ $installed_lang = getLang($version_parts,4);
 //error_log('latest_version: '.$latest_version);
 //error_log('langs: '.$current_lang.':'.$installed_lang);
 
-if (($version_parts[0] != $latest_version || $current_lang != $installed_lang) && !mac_filter($_SERVER['HTTP_X_ESP8266_STA_MAC'])) {
+if (($version_parts[0] != $latest_version || $current_lang != $installed_lang) && !mac_filter_latest_version($_SERVER['HTTP_X_ESP8266_STA_MAC'])) {
     sendFile("latest",$current_lang);
-} elseif (($version_parts[0] != $latest_version_beta) && mac_filter_beta($_SERVER['HTTP_X_ESP8266_STA_MAC'])) {
+} elseif (($version_parts[0] != $latest_version_beta) && mac_filter_beta_version($_SERVER['HTTP_X_ESP8266_STA_MAC'])) {
     sendFile("latest_beta",$current_lang);
 } else {
     header($_SERVER["SERVER_PROTOCOL"].' 304 Not Modified', true, 304);

--- a/update/firmware.php
+++ b/update/firmware.php
@@ -15,7 +15,12 @@ function check_header($name, $value = false) {
     return true;
 }
 
-function sendFile($path) {
+function sendFile($file,$lang) {
+    $path = './data/'.$file.'_'.$lang.'.bin';
+    if(!file_exists($path)){
+        $path = './data/'.$file.'.bin';
+    }
+    error_log("Download: ".$path.' -> '.file_exists($path));
     header($_SERVER["SERVER_PROTOCOL"].' 200 OK', true, 200);
     header('Content-Type: application/octet-stream', true);
     header('Content-Disposition: attachment; filename='.basename($path));
@@ -24,6 +29,33 @@ function sendFile($path) {
     readfile($path);
 }
 
+function getLang($version_parts,$index){
+    $lang = isset($version_parts[$index])?strtolower($version_parts[$index]):'de';
+    return in_array($lang, Array('de','en','bg'))?$lang:'de';   
+}
+
+function logHeaders(){
+    file_put_contents("headers.txt", gmdate("Y-m-d H:i:s")." - ".$_SERVER['HTTP_X_ESP8266_STA_MAC']." - ".$_SERVER['HTTP_X_ESP8266_AP_MAC']." - ".$_SERVER['HTTP_X_ESP8266_FREE_SPACE']." - ".$_SERVER['HTTP_X_ESP8266_SKETCH_SIZE']." - ".$_SERVER['HTTP_X_ESP8266_CHIP_SIZE']." - ".$_SERVER['HTTP_X_ESP8266_SDK_VERSION']." - ".$_SERVER['HTTP_X_ESP8266_VERSION']."\n", FILE_APPEND | LOCK_EX);
+}
+
+function mac_filter($mac){
+    $macs[] = "18:FE:34:CF:8C:70";
+    $macs[] = "18:FE:34:CF:7C:4B"; // Pragsattel outdoor
+    $macs[] = "60:01:94:06:9B:DB"; // Jule
+    $macs[] = "60:01:94:0B:54:A1"; // Greiz
+    $macs[] = "18:FE:34:D4:84:16";
+    return in_array($mac, $macs);
+}
+
+function mac_filter_beta($mac){
+    $macs[] = "18:FE:34:CF:7C:4B"; // Pragsattel outdoor
+    $macs[] = "60:01:94:06:9B:DB"; // Jule
+    $macs[] = "60:01:94:0B:54:A1"; // Greiz
+    $macs[] = "18:FE:34:CF:8C:70";
+    return in_array($mac, $macs);
+}
+
+//------------------------------------------------------------
 if(!check_header('HTTP_USER_AGENT', 'ESP8266-http-Update')) {
     header($_SERVER["SERVER_PROTOCOL"].' 403 Forbidden', true, 403);
     echo "only for ESP8266 updater!\n";
@@ -44,22 +76,20 @@ if(
     exit();
 }
 
-$version_parts = explode(" ",$_SERVER['HTTP_X_ESP8266_VERSION']);
-file_put_contents("headers.txt", gmdate("Y-m-d H:i:s")." - ".$_SERVER['HTTP_X_ESP8266_STA_MAC']." - ".$_SERVER['HTTP_X_ESP8266_AP_MAC']." - ".$_SERVER['HTTP_X_ESP8266_FREE_SPACE']." - ".$_SERVER['HTTP_X_ESP8266_SKETCH_SIZE']." - ".$_SERVER['HTTP_X_ESP8266_CHIP_SIZE']." - ".$_SERVER['HTTP_X_ESP8266_SDK_VERSION']." - ".$_SERVER['HTTP_X_ESP8266_VERSION']."\n", FILE_APPEND | LOCK_EX);
+logHeaders();
 
-if (($version_parts[0] != $latest_version) &&
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] != "18:FE:34:CF:8C:70") &&
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] != "18:FE:34:CF:7C:4B") &&		// Pragsattel outdoor
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] != "60:01:94:06:9B:DB") &&		// Jule
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] != "60:01:94:0B:54:A1") &&		// Greiz
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] != "18:FE:34:D4:84:16")) {
-    sendFile("./data/latest.bin");
-} elseif (($version_parts[0] != $latest_version_beta) &&
-	(($_SERVER['HTTP_X_ESP8266_STA_MAC'] == "18:FE:34:CF:7C:4B") ||		// Pragsattel outdoor
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] == "60:01:94:06:9B:DB") ||		// Jule
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] == "60:01:94:0B:54:A1") ||		// Greiz
-	($_SERVER['HTTP_X_ESP8266_STA_MAC'] == "18:FE:34:CF:8C:70"))) {
-    sendFile("./data/latest_beta.bin");
+$version_parts = explode(" ",$_SERVER['HTTP_X_ESP8266_VERSION']);
+$current_lang  = getLang($version_parts,3);
+$installed_lang = getLang($version_parts,4);
+
+//error_log(print_r($version_parts,true));
+//error_log('latest_version: '.$latest_version);
+//error_log('langs: '.$current_lang.':'.$installed_lang);
+
+if (($version_parts[0] != $latest_version || $current_lang != $installed_lang) && !mac_filter($_SERVER['HTTP_X_ESP8266_STA_MAC'])) {
+    sendFile("latest",$current_lang);
+} elseif (($version_parts[0] != $latest_version_beta) && mac_filter_beta($_SERVER['HTTP_X_ESP8266_STA_MAC'])) {
+    sendFile("latest_beta",$current_lang);
 } else {
     header($_SERVER["SERVER_PROTOCOL"].' 304 Not Modified', true, 304);
 }


### PR DESCRIPTION
This PR contains necessary changes in /update/firmware.php to support downloading of firmware with specific language interface. (reference: https://github.com/opendata-stuttgart/sensors-software/pull/75) 

**How it works:**
- data folder must contains a number of different language firmware version like "latest_de.bin", "latest_en.bin", "latest_bg.bin", ... etc
- sensor send request to checking for new version. Headers contains current version,...,current language, installed version.
- server return latest bin file if sensor have older version OR **if sensor have different current and install version** _(that mean that user choose new language and want to change it)_  

Please, make a review to this PR and comment. I am ready to change any parts that are not suitable to your roadmap. I believe it will help to promote the initiative in more countries.
